### PR TITLE
Write to intermediate .swp file to help avoid corruption issues

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -30,6 +30,7 @@ class SecoKeyval {
   constructor(file, header) {
     this.hasOpened = false;
     this.file = file;
+    this._swpFile = this.file + '.swp';
     this.header = header;
     this._data = {};
     this._hash = Buffer.alloc(0);
@@ -40,6 +41,7 @@ class SecoKeyval {
 
     return _asyncToGenerator(function* () {
       _this._seco = (0, _secoRw2.default)(_this.file, passphrase, _this.header);
+      _this._swpSeco = (0, _secoRw2.default)(_this._swpFile, passphrase, _this.header);
       if (yield _fsExtra2.default.pathExists(_this.file)) {
         let data = yield _this._seco.read();
         data = (0, _zlib.gunzipSync)(shrink32k(data));
@@ -65,7 +67,9 @@ class SecoKeyval {
 
       if (!_this2._hash.equals(hash)) {
         _this2._hash = hash;
-        yield _this2._seco.write(expand32k((0, _zlib.gzipSync)(data)));
+        yield _this2._swpSeco.write(expand32k((0, _zlib.gzipSync)(data)));
+        yield _fsExtra2.default.unlink(_this2.file);
+        yield _fsExtra2.default.rename(_this2._swpFile, _this2.file);
       }
     })();
   }

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ export default class SecoKeyval {
   constructor (file, header) {
     this.hasOpened = false
     this.file = file
+    this._swpFile = this.file + '.swp'
     this.header = header
     this._data = {}
     this._hash = Buffer.alloc(0)
@@ -16,6 +17,7 @@ export default class SecoKeyval {
 
   async open (passphrase, initalData = {}) {
     this._seco = createSecoRW(this.file, passphrase, this.header)
+    this._swpSeco = createSecoRW(this._swpFile, passphrase, this.header)
     if (await fs.pathExists(this.file)) {
       let data = await this._seco.read()
       data = gunzipSync(shrink32k(data))
@@ -37,7 +39,9 @@ export default class SecoKeyval {
 
     if (!this._hash.equals(hash)) {
       this._hash = hash
-      await this._seco.write(expand32k(gzipSync(data)))
+      await this._swpSeco.write(expand32k(gzipSync(data)))
+      await fs.unlink(this.file)
+      await fs.rename(this._swpFile, this.file)
     }
   }
 

--- a/src/seco-keyval.test.js
+++ b/src/seco-keyval.test.js
@@ -19,6 +19,7 @@ test('SecoKeyval open() / set()', async (t) => {
 
   // verify the file actually got created
   t.true(await fs.pathExists(walletFile), 'wallet exists')
+  t.false(await fs.pathExists(walletFile + '.swp'), '.swp file is deleted')
 
   const seco = createSecoRW(walletFile, passphrase)
   let data = await seco.read()


### PR DESCRIPTION
I can't figure out a sane way to unit-test this; ideas welcome.