### PR TITLE
Add changePassphrase() method

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,5 +5,10 @@
         "node": 6.5
       }
     }]
+  ],
+  "plugins": [
+    ["typecheck", { "disable": { "production": true } }],
+    "syntax-flow",
+    "transform-flow-strip-types"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ Sets `key` to `value`. Returns a promise resolving when the data has been writte
 
 Gets `key` and returns a Promise resolving to the value of `key`. Returns a Promise resolving to `undefined` if the key is not set.
 
+### `kv.changePassphrase(newPassphrase)`
+
+Changes the passphrase to `newPassphrase`. Returns a promise resolving when the data has been written to disk.
+
 ## License
 
 MIT

--- a/lib/index.js
+++ b/lib/index.js
@@ -83,6 +83,17 @@ class SecoKeyval {
     })();
   }
 
+  changePassphrase(newPassphrase) {
+    var _this4 = this;
+
+    return _asyncToGenerator(function* () {
+      if (!_this4.hasOpened) throw new Error('Must open first.');
+      _this4._seco = (0, _secoRw2.default)(_this4.file, newPassphrase, _this4.header);
+      _this4._swpSeco = (0, _secoRw2.default)(_this4._swpFile, newPassphrase, _this4.header);
+      yield _this4._seco.write(expand32k((0, _zlib.gzipSync)(Buffer.from(JSON.stringify(_this4._data)))));
+    })();
+  }
+
   inspect() {
     return `<SecoKeyval: ${this.file}>`;
   }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "colortape": "^0.1.2",
     "standard": "^10.0.2",
     "tape": "^4.6.3",
+    "tape-promise": "^2.0.1",
     "tempy": "^0.1.0"
   },
   "standard": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "test": "standard && tape -r babel-register **/*.test.js | colortape",
     "build": "babel src/ --out-dir lib --ignore test.js",
-    "posttest": "npm run build"
+    "posttest": "NODE_ENV=production npm run build"
   },
   "dependencies": {
     "buffer-noise": "^0.1.0",
@@ -25,6 +25,10 @@
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",
+    "babel-eslint": "^7.2.3",
+    "babel-plugin-syntax-flow": "^6.18.0",
+    "babel-plugin-transform-flow-strip-types": "^6.22.0",
+    "babel-plugin-typecheck": "^3.9.0",
     "babel-preset-env": "^1.4.0",
     "babel-register": "^6.24.1",
     "colortape": "^0.1.2",
@@ -34,6 +38,7 @@
     "tempy": "^0.1.0"
   },
   "standard": {
-    "ignore": "lib"
+    "ignore": "lib",
+    "parser": "babel-eslint"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ import { createHash } from 'crypto'
 const { expand: expand32k, shrink: shrink32k } = createExpander(2 ** 15)
 
 export default class SecoKeyval {
-  constructor (file, header) {
+  constructor (file: string, header: {| appName: string, appVersion: string |}) {
     this.hasOpened = false
     this.file = file
     this._swpFile = this.file + '.swp'
@@ -15,7 +15,7 @@ export default class SecoKeyval {
     this._hash = Buffer.alloc(0)
   }
 
-  async open (passphrase, initalData = {}) {
+  async open (passphrase: Buffer | string, initalData = {}) {
     this._seco = createSecoRW(this.file, passphrase, this.header)
     this._swpSeco = createSecoRW(this._swpFile, passphrase, this.header)
     if (await fs.pathExists(this.file)) {
@@ -30,7 +30,7 @@ export default class SecoKeyval {
     this.hasOpened = true
   }
 
-  async set (key, val) {
+  async set (key: string, val: any) {
     if (!this.hasOpened) throw new Error('Must open first.')
     this._data[key] = val
 
@@ -45,12 +45,12 @@ export default class SecoKeyval {
     }
   }
 
-  async get (key) {
+  async get (key: string) {
     if (!this.hasOpened) throw new Error('Must open first.')
     return this._data[key]
   }
 
-  async changePassphrase (newPassphrase) {
+  async changePassphrase (newPassphrase: Buffer | string) {
     if (!this.hasOpened) throw new Error('Must open first.')
     this._seco = createSecoRW(this.file, newPassphrase, this.header)
     this._swpSeco = createSecoRW(this._swpFile, newPassphrase, this.header)

--- a/src/index.js
+++ b/src/index.js
@@ -50,6 +50,13 @@ export default class SecoKeyval {
     return this._data[key]
   }
 
+  async changePassphrase (newPassphrase) {
+    if (!this.hasOpened) throw new Error('Must open first.')
+    this._seco = createSecoRW(this.file, newPassphrase, this.header)
+    this._swpSeco = createSecoRW(this._swpFile, newPassphrase, this.header)
+    await this._seco.write(expand32k(gzipSync(Buffer.from(JSON.stringify(this._data)))))
+  }
+
   inspect () {
     return `<SecoKeyval: ${this.file}>`
   }

--- a/src/seco-keyval.test.js
+++ b/src/seco-keyval.test.js
@@ -1,4 +1,4 @@
-import test from 'tape'
+import test from 'tape-promise/tape'
 import { file as tempFile } from 'tempy'
 import createSecoRW from 'seco-rw'
 import createExpander from 'buffer-noise'

--- a/src/seco-keyval.test.js
+++ b/src/seco-keyval.test.js
@@ -88,6 +88,34 @@ test('SecoKeyval open() with initalData / get()', async (t) => {
   t.end()
 })
 
+test('SecoKeyval changePassphrase()', async (t) => {
+  const passphrase1 = Buffer.from('please let me in')
+  const passphrase2 = Buffer.from('a-longer-and-more-secure-passphrase')
+  const walletFile = tempFile()
+
+  let kv = new SecoKeyval(walletFile, { appName: 'test', appVersion: '1.0.0' })
+  await kv.open(passphrase1)
+
+  const p1 = { name: 'JP' }
+  const p2 = { name: 'Daniel' }
+
+  await kv.set('person1', p1)
+  await kv.set('person2', p2)
+
+  await kv.changePassphrase(passphrase2)
+
+  let kv2 = new SecoKeyval(walletFile, { appName: 'test', appVersion: '1.0.0' })
+  await kv2.open(passphrase2)
+
+  const gp1 = await kv2.get('person1')
+  const gp2 = await kv2.get('person2')
+
+  t.same(gp1, p1, 'person 1')
+  t.same(gp2, p2, 'person 2')
+
+  t.end()
+})
+
 test('get() & set() error if called before open()', async (t) => {
   t.plan(2)
   const walletFile = tempFile()


### PR DESCRIPTION
@jprichardson The old local module had a `write` method that was only used for changing the passphrase. A `write` method doesn't really make sense, since we're writing to the file on every `set` call, so I didn't add it to seco-keyval.

However, that disables our `kv._data` hack, since there's no way to prompt a write to file. I decided it might make a bit more sense to simply add a `changePassphrase` method instead of adding `write` just to allow this hack. Let me know if you disagree.

---

Also switched to tape-promise for better test reporting