### PR TITLE
update hash on delete key

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -62,6 +62,11 @@ export default class SecoKeyval {
     // Only need to delete and write if the key actually exists in the first place
     if (this._data.hasOwnProperty(key)) {
       delete this._data[key]
+
+      const data = Buffer.from(JSON.stringify(this._data))
+      const hash = createHash('sha256').update(data).digest()
+      this._hash = hash
+
       await this._seco.write(expand32k(gzipSync(Buffer.from(JSON.stringify(this._data)))))
     }
   }

--- a/src/seco-keyval.test.js
+++ b/src/seco-keyval.test.js
@@ -78,11 +78,16 @@ test('SecoKeyval open() / set() / delete() / get()', async (t) => {
   let kv2 = new SecoKeyval(walletFile, { appName: 'test', appVersion: '1.0.0' })
   await kv2.open(passphrase)
 
-  const gp1 = await kv2.get('person1')
+  let gp1 = await kv2.get('person1')
   const gp2 = await kv2.get('person2')
 
   t.same(gp1, undefined, 'person 1 was deleted')
   t.same(gp2, p2, 'person 2')
+
+  await kv2.set('person1', p1)
+  gp1 = await kv2.get('person1')
+
+  t.same(gp1, p1, 'person 1 was restored after deleting')
 
   t.end()
 })

--- a/src/seco-keyval.test.js
+++ b/src/seco-keyval.test.js
@@ -78,16 +78,33 @@ test('SecoKeyval open() / set() / delete() / get()', async (t) => {
   let kv2 = new SecoKeyval(walletFile, { appName: 'test', appVersion: '1.0.0' })
   await kv2.open(passphrase)
 
-  let gp1 = await kv2.get('person1')
+  const gp1 = await kv2.get('person1')
   const gp2 = await kv2.get('person2')
 
   t.same(gp1, undefined, 'person 1 was deleted')
   t.same(gp2, p2, 'person 2')
 
-  await kv2.set('person1', p1)
-  gp1 = await kv2.get('person1')
+  t.end()
+})
 
-  t.same(gp1, p1, 'person 1 was restored after deleting')
+test('SecoKeyval data can be deleted, restored, and is written to disk', async (t) => {
+  const passphrase = Buffer.from('please let me in')
+  const walletFile = tempFile()
+
+  const kv = new SecoKeyval(walletFile, { appName: 'test', appVersion: '1.0.0' })
+  await kv.open(passphrase)
+
+  const data = { value: true }
+  await kv.set('key', data)
+  await kv.delete('key')
+  await kv.set('key', data)
+
+  const kv2 = new SecoKeyval(walletFile, { appName: 'test', appVersion: '1.0.0' })
+  await kv2.open(passphrase)
+
+  const fetchedData = await kv2.get('key')
+
+  t.same(fetchedData, data, 'data is restored after deleting')
 
   t.end()
 })


### PR DESCRIPTION
Currently we do not update `this._hash` after deleting a key. This means if you delete a key (or several), and then immediately try again to return the data to it's previous state pre-deleting, the hashes are compared and are equal, so the instance passes without updating itself.