### PR TITLE
feat: support batching operations together

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "git+https://github.com/ExodusMovement/seco-keyval.git"
   },
   "scripts": {
-    "test": "standard && tape -r babel-register **/*.test.js | colortape",
+    "test": "standard && tape -r babel-register src/**/*.test.js | colortape",
     "build": "babel src/ --out-dir lib --ignore test.js",
     "posttest": "NODE_ENV=production npm run build"
   },


### PR DESCRIPTION
## the problem

set/delete are currently per-key, and result in the entire file being written

## solution

a batch api lets the caller maintain a kind of queue, and flush all writes at the end

```js
const promise = store.batch()
  // add as many operations as you want
  .add({ type: 'set', key: 'abc', value: '123' })
  .add({ type: 'delete', key: 'efg' })
  // flush
  .exec()
```

the main problem will probably be solved by https://github.com/ExodusMovement/exodus-desktop/pull/8034  and https://github.com/ExodusMovement/exodus-desktop/pull/8035 but it would still be nice to be able to batch ops together and save time on writes

the below is what i get on restore ~on master~ with batching added on top of master (ignore the times, the blue numbers are the batch sizes):
<img width="412" alt="batcher" src="https://user-images.githubusercontent.com/83948/86296678-5fe5c080-bbc7-11ea-95d6-02355e3ed729.png">


when running on top of the PRs linked above, it's way better, but might still be worth it in case we have bursts:
![image](https://user-images.githubusercontent.com/83948/86300614-6c6f1680-bbd1-11ea-91d3-a9c27e519906.png)
