### PR TITLE
DNRY: add .flush() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Deletes `key`. Returns a promise resolving when the data has been written to dis
 
 ### `kv.flush(force)`
 
-Conditionally syncs all in-memory changes to disk. This is done automatically by `.get`, `.delete`, `.changePassphrase`, and `.setAllData`.
+Conditionally syncs all in-memory changes to disk. This is done automatically by `.set`, `.delete`, `.changePassphrase`, and `.setAllData`.
 
 This method only writes to disk if the key-value store's in-memory data has changed since the last `flush`. This behavior can be overridden by passing `true` as the `force` parameter.
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ Gets `key` and returns the value of `key`. Returns `undefined` if the key is not
 
 Deletes `key`. Returns a promise resolving when the data has been written to disk.
 
+### `kv.flush(force)`
+
+Conditionally syncs all in-memory changes to disk. This is done automatically by `.get`, `.delete`, `.changePassphrase`, and `.setAllData`.
+
+This method only writes to disk if the key-value store's in-memory data has changed since the last `flush`. This behavior can be overridden by passing `true` as the `force` parameter.
+
 ### `kv.changePassphrase(newPassphrase)`
 
 Changes the passphrase to `newPassphrase`. Returns a promise resolving when the data has been written to disk.

--- a/src/index.js
+++ b/src/index.js
@@ -64,7 +64,7 @@ export default class SecoKeyval {
     const data = Buffer.from(JSON.stringify(this._data))
     const hash = createHash('sha256').update(data).digest()
 
-    if (!this._hashSinceLastFlush.equals(hash) || force) {
+    if (force || !this._hashSinceLastFlush.equals(hash)) {
       this._hashSinceLastFlush = hash
       await this._seco.write(expand32k(gzipSync(data)))
     }


### PR DESCRIPTION
Simplifies the duplicated pattern of writing the seco-keyval instance to disk in one tidy async method.