### PR TITLE
add memset/memdelete methods for performance enthusiasts

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ Gets `key` and returns the value of `key`. Returns `undefined` if the key is not
 
 Deletes `key`. Returns a promise resolving when the data has been written to disk.
 
+### `kv.memset(key, value)`
+
+Sets `key` to `value` in memory only. Useful for performance to cache a series of changes in memory before using `.flush()` to write them to disk.
+
+### `kv.memdelete(key, value)`
+
+Deletes `key` in memory only. Serves a similar purpose to the `.memset(key, value)` method.
+
 ### `kv.flush(force)`
 
 Conditionally syncs all in-memory changes to disk. This is done automatically by `.set`, `.delete`, `.changePassphrase`, and `.setAllData`.

--- a/src/index.js
+++ b/src/index.js
@@ -39,24 +39,33 @@ export default class SecoKeyval {
   }
 
   async set (key: string, val: any) {
-    if (!this.hasOpened) throw new Error('Must open first.')
-    this._data[key] = val
+    this.memset(key, val)
     await this.flush()
   }
 
-  get (key: string) {
-    if (!this.hasOpened) throw new Error('Must open first.')
-    return this._data[key]
+  async delete (key: string) {
+    const hadKey = this._data.hasOwnProperty(key)
+    this.memdelete(key)
+    if (hadKey) await this.flush()
   }
 
-  async delete (key: string) {
+  memset (key: string, val: any) {
+    if (!this.hasOpened) throw new Error('Must open first.')
+    this._data[key] = val
+  }
+
+  memdelete (key: string) {
     if (!this.hasOpened) throw new Error('Must open first.')
 
     // Only need to delete and write if the key actually exists in the first place
     if (this._data.hasOwnProperty(key)) {
       delete this._data[key]
-      await this.flush()
     }
+  }
+
+  get (key: string) {
+    if (!this.hasOpened) throw new Error('Must open first.')
+    return this._data[key]
   }
 
   // Conditionally write changes to disk


### PR DESCRIPTION
Alternative to #11 with a cleaner diff set.

Adds two new synchronous methods: `kv.memset(k, v)` and `kv.memdelete(k)`. These two methods effect the same changes as `.set` or `.delete` but without writing the changes to disk. 

To write the in-memory changes to disk, a seco-keyval consumer should explicitly call `.flush`, although a call to `.set` or `.delete` will also sync the changes to disk.

The primary purpose of this change is to allow consumers to buffer high-frequency changes and write them all together when they are done.