### PR TITLE
BREAKING: Bump Node version support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
 node_js:
-  - "6"
+  - node
+  - 12


### PR DESCRIPTION
Fixes Travis, https://github.com/cryptocoinjs/scryptsy broke semver, way down in the deps tree, by adding `async` usage without semver-major.